### PR TITLE
add npm audit policies rfc

### DIFF
--- a/accepted/0000-npm-audit-policies.md
+++ b/accepted/0000-npm-audit-policies.md
@@ -1,0 +1,89 @@
+# Audit Policies
+
+### Motivation
+
+Today there are a limited set of conditions in place that prevent the installation of a package (ex. integrity mismatches & engines conflicts); audits also happen post-installation meaning they are only advisory in practice.
+
+### Solution
+
+Introduce easily configurable audit definitions that can gate the installation of packages. This new feature should leverage existing functionality/commands (ex. `install`, `update` & `audit`), syntax (ex. Dependency Selectors) & metadata without expanding the scope to unbounded, arbitrary code execution (unlike `preinstall` scripts or lifecycle hooks).
+
+### Known Caveats
+- Adding extra validation during installation will slow down execution
+  - this will be up to end-users to control & determine what validations are necessary to meet their own requirements
+- Not all usecases will be met
+  - we will be limited by the existing commands, syntax & metadata supported
+  - we aim to meet 80% (or the majority) of usecases with this feature
+  - end-users with broader security needs can & still should look at locking down developer environments & enforce policies at the system/network level (something that is outside the scope of the `npm` CLI today)
+
+### Implementation
+
+```json
+{
+    "audit": {
+        "policies": [
+            {
+                "name": "Vulnerable",
+                "type": "error",
+                "query": ":vulnerable"
+            },
+            {
+                "name": "Peer Conflicts",
+                "type": "error",
+                "query": ".peer:not(:deduped)"
+            },
+            {
+                "name": "Deprecated",
+                "type": "warn",
+                "query": ":deprecated"
+            },
+            {
+                "name": "Outdated",
+                "type": "log",
+                "query": ":outdated()"
+            },
+            {
+                "name": "Licenses",
+                "type": "log",
+                "query": ":not([license=MIT])"
+            },
+            {
+                "name": "Remotes",
+                "type": "error",
+                "query": ":type(git), :type(remote)"
+            },
+            {
+                "name": "Extraneous",
+                "type": "warn",
+                "query": ":extraneous"
+            },
+            {
+                "name": "Missing",
+                "type": "warn",
+                "query": ":missing"
+            },
+            {
+                "name": "Duplicate Peers",
+                "type": "warn",
+                "query": ".peer:not(:deduped)"
+            },
+            {
+                "name": "Bad Packages",
+                "type": "error",
+                "query": "#phishing, #spam, #malware"
+            },
+            {
+                "name": "Bad Actors",
+                "type": "error",
+                "query": ":attr(contributors, [email=bad@example.com])"
+            },
+            {
+                "name": "Architecture Mismatch",
+                "type": "error",
+                "query": "@supports(cpu:x64) { [cpu=!x64] }"
+            }
+        ]
+    }
+}
+```
+


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new feature to npm that allows users to define audit policies to control package installation based on specific criteria, enhancing security and compliance during the package installation process.

New Features:
- Introduce configurable audit policies to gate the installation of npm packages based on various criteria such as vulnerabilities, peer conflicts, deprecated packages, outdated packages, license types, remote sources, extraneous packages, missing packages, duplicate peers, bad packages, bad actors, and architecture mismatches.

<!-- Generated by sourcery-ai[bot]: end summary -->